### PR TITLE
feat: add reply to Nodemailer SMTP config

### DIFF
--- a/lib/private/mail/send.js
+++ b/lib/private/mail/send.js
@@ -88,6 +88,12 @@ module.exports = {
       defaultsTo: sails.config.mail.from.name || process.env.MAIL_FROM_NAME
     },
 
+    replyTo: {
+      description: 'An email address that will appear on the Reply-To: field',
+      example: 'example@example.com',
+      defaultsTo: sails.config.mail.replyTo || process.env.MAIL_REPLY_TO      
+    },
+
     layout: {
       description:
         'Set to `false` to disable layouts altogether, or provide the path (relative ' +
@@ -123,6 +129,7 @@ module.exports = {
     mailer,
     from: fromAddress,
     fromName,
+    replyTo,
     text,
     cc,
     bcc,
@@ -215,6 +222,7 @@ module.exports = {
           html,
           cc,
           bcc,
+          replyTo,
           attachments
         })
         sails.log.debug('Email sent: %s', smtpInfo.messageId)


### PR DESCRIPTION
Hi! This config sometimes is required to route replies to a different email.

About the config: https://nodemailer.com/message/#more-advanced-fields