### PR TITLE
Remove email prefix noise from mail template names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your Sails action you can use the `send` helper like so:
 ```js
 await sails.helpers.mail.send.with({
   subject: 'Verify your email',
-  template: 'email-verify-account',
+  template: 'verify-account',
   to: user.email,
   templateData: {
     token: user.emailProofToken,
@@ -23,6 +23,10 @@ await sails.helpers.mail.send.with({
   }
 })
 ```
+
+Template names are relative to `views/emails/`, so `template: 'verify-account'`
+maps to `views/emails/verify-account.ejs`. Existing templates and callers that
+still use names like `email-verify-account` continue to work too.
 
 ## Mailers
 

--- a/lib/private/mail/send.js
+++ b/lib/private/mail/send.js
@@ -1,3 +1,5 @@
+const path = require('node:path')
+
 module.exports = {
   friendlyName: 'Send',
 
@@ -16,8 +18,8 @@ module.exports = {
         'The relative path to an EJS template within our `views/emails/` folder -- WITHOUT the file extension.',
       extendedDescription:
         'Use strings like "foo" or "foo/bar", but NEVER "foo/bar.ejs" or "/foo/bar".  For example, ' +
-        '"internal/email-contact-form" would send an email using the "views/emails/internal/email-contact-form.ejs" template.',
-      example: 'email-reset-password',
+        '"internal/contact-form" would send an email using the "views/emails/internal/contact-form.ejs" template.',
+      example: 'reset-password',
       type: 'string'
     },
 
@@ -184,32 +186,20 @@ module.exports = {
     react,
     scheduledAt
   }) {
-    if (template && !template.startsWith('email-')) {
-      sails.log.warn(
-        'The "template" that was passed in to `send()` does not begin with ' +
-          '"email-" -- but by convention, all email template files in `views/emails/` should ' +
-          'be namespaced in this way.  (This makes it easier to look up email templates by ' +
-          'filename; e.g. when using CMD/CTRL+P in Sublime Text.)\n' +
-          'Continuing regardless...'
-      )
-    }
-    if (
-      template &&
-      (template.startsWith('views/') || template.startsWith('views/'))
-    ) {
+    if (template && /^(emails|views)\//.test(template)) {
       throw new Error(
-        'The "template" that was passed in to `sendTemplateEmail()` was prefixed with\n' +
+        'The "template" that was passed in to `send()` was prefixed with\n' +
           '`emails/` or `views/` -- but that part is supposed to be omitted.  Instead, please\n' +
           'just specify the path to the desired email template relative from `views/emails/`.\n' +
           'For example:\n' +
-          "  template: 'email-reset-password'\n" +
+          "  template: 'reset-password'\n" +
           'Or:\n' +
-          "  template: 'admin/email-contact-form'\n" +
+          "  template: 'admin/contact-form'\n" +
+          'Legacy names like `email-reset-password` are also supported.\n' +
           " [?] If you're unsure or need advice, see https://sailsjs.com/support"
       )
     } //•
     // Determine appropriate email layout and template to use.
-    const path = require('path')
     const emailTemplatePath = path.join('emails/', template)
     let emailTemplateLayout
     if (layout) {


### PR DESCRIPTION
## Summary
- remove the warning that nudged every mail template toward an `email-` prefix
- keep template lookup simple by continuing to use the exact path passed to `send()`
- update the helper docs and examples to prefer shorter template names like `verify-account`

## Verification
- npm run lint

Closes #30
