### PR TITLE
Rename default email layout to mail

### DIFF
--- a/lib/private/mail/send.js
+++ b/lib/private/mail/send.js
@@ -82,7 +82,7 @@ module.exports = {
       description:
         'Set to `false` to disable layouts altogether, or provide the path (relative ' +
         'from `views/layouts/`) to an override email layout.',
-      defaultsTo: 'layout-email',
+      defaultsTo: 'mail',
       custom: (layout) => layout === false || typeof layout === 'string'
     },
     waitForAcknowledgement: {


### PR DESCRIPTION
## Summary
- change the default email layout from `layout-email` to `mail`
- keep custom layout lookup relative to `views/layouts/`
- leave docs.sailscasts.com follow-up for the matching docs references

## Verification
- npm run lint

Closes #32
